### PR TITLE
Fix NVIDIA API client type hints

### DIFF
--- a/app/adapters/ai/nvidia/client.py
+++ b/app/adapters/ai/nvidia/client.py
@@ -25,8 +25,8 @@ class NVIDIAClient:
             self,
             api_key: Optional[str] = None,
             base_url: Optional[str] = None,
-            timeout: Optional[str] = None,
-            max_retries: Optional[str] = None,
+            timeout: Optional[int] = None,
+            max_retries: Optional[int] = None,
     ):
         """
         Initialize NVIDIA API client.


### PR DESCRIPTION
Fix type hints for timeout and max_retries parameters

**Problem:**
The timeout and max_retries parameters in NVIDIAClient.__init__ were incorrectly typed as Optional[str] instead of Optional[int]. This would cause type errors when passing integer values.

**Solution:**
Updated the type hints to match the actual parameter usage and settings defaults.

**Changes:**
- Changed timeout parameter from Optional[str] to Optional[int]
- Changed max_retries parameter from Optional[str] to Optional[int]

This resolves the NVIDIA API client initialization issues and ensures proper type safety.